### PR TITLE
fix: change session cookie sameSite from 'lax' to 'strict'

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -94,7 +94,7 @@ export async function POST(request: NextRequest) {
     response.cookies.set('session', sessionId, {
       httpOnly: true,
       secure: isSecure,
-      sameSite: 'lax',
+      sameSite: 'strict',
       expires: expiresAt,
       path: '/',
     });


### PR DESCRIPTION
Improves CSRF protection by preventing cookies from being sent
on cross-site requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session cookie security policy to restrict cross-site request cookie transmission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->